### PR TITLE
feat(cli): add agents suggest command for agent recommendations

### DIFF
--- a/src/claude_builder/cli/agent_commands.py
+++ b/src/claude_builder/cli/agent_commands.py
@@ -1,0 +1,219 @@
+"""Agent suggestion CLI commands for Claude Builder.
+
+Provides an ergonomic entry point to surface agent recommendations based on:
+- Natural-language trigger phrases (P2.3.2/3)
+- Detected DevOps/MLOps signals from project analysis (P2.3.1)
+"""
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import click
+
+from rich.console import Console
+from rich.table import Table
+
+from claude_builder.core.agents import AgentRegistry, AgentSelector
+from claude_builder.core.analyzer import ProjectAnalyzer
+from claude_builder.core.models import AgentInfo
+
+
+console = Console()
+
+
+@click.group()
+def agents() -> None:
+    """Agent-related commands for Claude Builder.
+
+    Examples:
+        claude-builder agents suggest --project-path ./my-project
+        claude-builder agents suggest --text "pipeline is failing"
+        claude-builder agents suggest --project-path . --mlops --json
+    """
+
+
+@agents.command()
+@click.option(
+    "--project-path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True),
+    default=".",
+    help="Project directory to analyze (default: current directory)",
+)
+@click.option("--text", help="Suggest agents based on a natural-language phrase")
+@click.option("--mlops", is_flag=True, help="Filter suggestions to MLOps/Data agents")
+@click.option(
+    "--devops", is_flag=True, help="Filter suggestions to DevOps/Infra agents"
+)
+@click.option("--json", "output_json", is_flag=True, help="Output results as JSON")
+@click.option("--verbose", "-v", count=True, help="Verbose output")
+def suggest(
+    project_path: str,
+    text: Optional[str],
+    mlops: bool,
+    devops: bool,
+    output_json: bool,
+    verbose: int,
+) -> None:
+    """Suggest agents from triggers or environment signals.
+
+    If --text is provided, suggestions are based on trigger phrases.
+    Otherwise, a quick analysis runs and environment-driven suggestions are shown.
+    Use --mlops/--devops to focus results, and --json for machine output.
+    """
+    registry = AgentRegistry()
+    selector = AgentSelector(registry)
+
+    suggestions: List[AgentInfo] = []
+    reasons: Dict[str, str] = {}
+
+    if text:
+        if verbose:
+            console.print(f"[cyan]Trigger phrase:[/cyan] {text}")
+        trigger_agents = selector.select_from_text(text)
+        for a in trigger_agents:
+            if a.name not in reasons:
+                suggestions.append(a)
+                reasons[a.name] = f"trigger: {text}"
+        source = "text"
+    else:
+        path = Path(project_path).resolve()
+        if verbose:
+            console.print(f"[cyan]Analyzing project:[/cyan] {path}")
+        analyzer = ProjectAnalyzer()
+        analysis = analyzer.analyze(path)
+
+        env_agents = selector.select_environment_agents(analysis)
+        for a in env_agents:
+            if a.name not in reasons:
+                suggestions.append(a)
+                # coarse-grained reason buckets
+                if _is_devops_agent(a.name):
+                    reasons[a.name] = "env: DevOps infrastructure"
+                elif _is_mlops_agent(a.name):
+                    reasons[a.name] = "env: MLOps/Data tools"
+                else:
+                    reasons[a.name] = "env: detected tools"
+
+        # If no specific focus requested, include comparative core/domain/workflow picks
+        if not mlops and not devops:
+            for a in selector.select_core_agents(analysis):
+                if a.name not in reasons:
+                    suggestions.append(a)
+                    reasons[a.name] = (
+                        f"core: {analysis.language_info.primary or 'general'}"
+                    )
+            for a in selector.select_domain_agents(analysis):
+                if a.name not in reasons:
+                    suggestions.append(a)
+                    reasons[a.name] = (
+                        f"domain: {analysis.domain_info.domain or 'general'}"
+                    )
+            for a in selector.select_workflow_agents(analysis):
+                if a.name not in reasons:
+                    suggestions.append(a)
+                    reasons[a.name] = f"workflow: {analysis.complexity_level.value}"
+        source = "env"
+
+    # Focus filters
+    if mlops:
+        suggestions = [a for a in suggestions if _is_mlops_agent(a.name)]
+    if devops:
+        suggestions = [a for a in suggestions if _is_devops_agent(a.name)]
+
+    # Sort by confidence (desc)
+    suggestions.sort(key=lambda a: (a.confidence or 0.5), reverse=True)
+
+    if output_json:
+        _print_json(suggestions, reasons, source)
+    else:
+        _print_table(suggestions, reasons, project_path, text)
+
+
+def _is_devops_agent(name: str) -> bool:
+    name_l = name.lower()
+    devops_keywords = [
+        "terraform",
+        "ansible",
+        "kubernetes",
+        "helm",
+        "pulumi",
+        "cloudformation",
+        "packer",
+        "observability",
+        "ci",
+        "pipeline",
+        "security",
+    ]
+    return any(k in name_l for k in devops_keywords)
+
+
+def _is_mlops_agent(name: str) -> bool:
+    name_l = name.lower()
+    mlops_keywords = [
+        "mlops",
+        "mlflow",
+        "kubeflow",
+        "dbt",
+        "airflow",
+        "prefect",
+        "dvc",
+        "data-quality",
+        "analyst",
+        "pipeline",
+        "model",
+    ]
+    return any(k in name_l for k in mlops_keywords)
+
+
+def _print_json(agents: List[AgentInfo], reasons: Dict[str, str], source: str) -> None:
+    payload: List[Dict[str, Any]] = []
+    for a in agents:
+        payload.append(
+            {
+                "name": a.name,
+                "role": a.role,
+                "confidence": a.confidence or 0.5,
+                "source": source,
+                "reasons": [reasons.get(a.name, "")],
+                "description": a.description,
+                "use_cases": a.use_cases,
+            }
+        )
+    # Use click.echo to avoid Rich markup processing of JSON content
+    click.echo(json.dumps(payload, indent=2))
+
+
+def _print_table(
+    agents: List[AgentInfo],
+    reasons: Dict[str, str],
+    project_path: str,
+    text: Optional[str],
+) -> None:
+    if not agents:
+        console.print("[yellow]No agent suggestions found.[/yellow]")
+        return
+
+    table = Table(title="Agent Suggestions")
+    table.add_column("Agent", style="cyan", no_wrap=True)
+    table.add_column("Role", style="green")
+    table.add_column("Confidence", style="magenta", justify="right")
+    table.add_column("Reason", style="blue")
+
+    for a in agents[:15]:
+        conf = f"{(a.confidence or 0.5) * 100:.0f}%"
+        table.add_row(a.name, a.role or "", conf, reasons.get(a.name, ""))
+
+    console.print()
+    if text:
+        console.print(f"[bold]Suggestions for:[/bold] '{text}'")
+    else:
+        console.print(f"[bold]Suggestions for:[/bold] {project_path}")
+    console.print(table)
+    if len(agents) > 15:
+        console.print(
+            f"\n[dim]... and {len(agents) - 15} more. Use --json for the full list.[/dim]"
+        )

--- a/src/claude_builder/cli/main.py
+++ b/src/claude_builder/cli/main.py
@@ -22,6 +22,7 @@ from claude_builder.utils.git import GitIntegrationManager
 from claude_builder.utils.validation import validate_project_path
 
 # Import subcommands
+from .agent_commands import agents
 from .analyze_commands import analyze
 from .config_commands import config
 from .generate_commands import generate
@@ -505,6 +506,7 @@ def _display_summary(project_path: Path, *, dry_run: bool) -> None:
 
 # Register subcommands
 cli.add_command(templates)
+cli.add_command(agents)
 cli.add_command(analyze)
 cli.add_command(generate)
 cli.add_command(config)

--- a/tests/unit/cli/test_agent_commands.py
+++ b/tests/unit/cli/test_agent_commands.py
@@ -1,0 +1,78 @@
+"""Tests for the agents CLI group (agents suggest)."""
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from claude_builder.cli.agent_commands import agents as agents_group
+from claude_builder.core.models import (
+    DevelopmentEnvironment,
+    ProjectAnalysis,
+    ProjectType,
+)
+
+
+def test_suggest_text_pipeline_invokes_ci_agent(monkeypatch: Any) -> None:
+    """--text 'pipeline is failing' should include ci-pipeline-engineer."""
+    # No registry mocking needed; DevOps agents are registered by default
+    runner = CliRunner()
+    result = runner.invoke(agents_group, ["suggest", "--text", "pipeline is failing"])
+    assert result.exit_code == 0
+    assert "ci-pipeline-engineer" in result.output
+
+
+def test_suggest_env_terraform_k8s(monkeypatch: Any, tmp_path: Path) -> None:
+    """Project with Terraform+Kubernetes should include appropriate agents."""
+    # Patch ProjectAnalyzer.analyze to return synthetic environment
+    from claude_builder.cli import agent_commands as mod
+
+    def fake_analyze(self, path: Path) -> ProjectAnalysis:  # type: ignore[override]
+        env = DevelopmentEnvironment(
+            infrastructure_as_code=["terraform"],
+            orchestration_tools=["kubernetes"],
+            ci_cd_systems=["github_actions"],
+        )
+        return ProjectAnalysis(
+            project_path=path,
+            project_type=ProjectType.API_SERVICE,
+            dev_environment=env,
+        )
+
+    monkeypatch.setattr(mod.ProjectAnalyzer, "analyze", fake_analyze)
+
+    runner = CliRunner()
+    result = runner.invoke(agents_group, ["suggest", "--project-path", str(tmp_path)])
+    assert result.exit_code == 0
+    # Expect terraform specialist and kubernetes operator at minimum
+    assert "terraform-specialist" in result.output
+    assert "kubernetes-operator" in result.output
+    # CI signal suggests ci-pipeline-engineer
+    assert "ci-pipeline-engineer" in result.output
+
+
+def test_suggest_json_output(monkeypatch: Any) -> None:
+    """--json should emit valid JSON array with required fields."""
+    runner = CliRunner()
+    result = runner.invoke(
+        agents_group, ["suggest", "--text", "harden cluster", "--json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert all("name" in item and "role" in item for item in payload)
+
+
+def test_suggest_mlops_filter(monkeypatch: Any) -> None:
+    """--mlops should filter to MLOps-oriented agents."""
+    runner = CliRunner()
+    res = runner.invoke(agents_group, ["suggest", "--text", "ml pipeline", "--mlops"])
+    assert res.exit_code == 0
+    # Should include mlops-engineer (mapped from 'ml pipeline')
+    assert "mlops-engineer" in res.output
+    # And should not include CI agent
+    assert "ci-pipeline-engineer" not in res.output


### PR DESCRIPTION
Adds a new CLI group 'agents' with subcommand 'suggest' to recommend agents from:

- Natural-language triggers (e.g., 'pipeline is failing', 'terraform drift')
- Detected DevOps/MLOps signals from project analysis

Highlights
- Options: --project-path, --text, --mlops, --devops, --json, -v
- Rich table output and stable JSON (name, role, confidence, source, reasons)
- Integrated into main CLI and covered by unit tests (4 passing)

Usage
- claude-builder agents suggest --text 'pipeline is failing'
- claude-builder agents suggest --project-path . --json
- claude-builder agents suggest --project-path . --mlops

Notes
- Hooks (isort/black/ruff/mypy) pass on this branch.
- Broader test suite has unrelated failures tracked separately; the new tests for this feature pass.
