### PR TITLE
Add DevOps/MLOps domain templates, integration, and focused tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,11 +240,12 @@ CLAUDE.md when relevant tools are detected in a project.
 
 Example snippet:
 
-````markdown
+```jinja
 {% if dev_environment.tools.kubernetes %}
 ### Kubernetes Deployments
 
 Define resource requests/limits and probes. Example:
+```
 
 ```yaml
 livenessProbe:
@@ -254,10 +255,6 @@ livenessProbe:
 ```
 
 {% endif %}
-
-````
-
-<a name="code-standards"></a>
 
 ## Code Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,62 @@ For new templates:
 - **Test cases** to validate template generation
 - **Examples** of generated output
 
+### Domain Template Guidelines (DevOps & MLOps)
+
+Domain templates provide infrastructure and MLOps guidance that is appended to
+CLAUDE.md when relevant tools are detected in a project.
+
+- Location: `src/claude_builder/templates/domains/{devops,mlops}`
+- Filenames: `INFRA.md`, `DEPLOYMENT.md`, `OBSERVABILITY.md`, `SECURITY.md`,
+  `MLOPS.md`, `DATA_PIPELINE.md`, `ML_GOVERNANCE.md`
+- Rendering: Sections are included only when matching tools are present in the
+  analysis. Gating is handled by the generator, and you can also use
+  conditionals inside templates.
+- Supported syntax:
+  - Conditionals: `{% if dev_environment.tools.terraform %} ... {% endif %}`
+  - Loops: `{% for file in dev_environment.tools.terraform.files %} ...`
+    `{% endfor %}`
+  - Variables: `{{ dev_environment.tools.terraform.confidence }}`
+  - Dotted paths are supported in `if/for` and `{{ }}` expressions.
+- Available context:
+  - `dev_environment.tools` is a dict keyed by lowercase tool name
+    (`terraform`, `kubernetes`, `helm`, `prometheus`, `grafana`, `opentelemetry`,
+    `vault`, `tfsec`, `trivy`, `mlflow`, `airflow`, `prefect`, `dagster`, `dvc`,
+    `dbt`, `great_expectations`, `feast`, etc.).
+  - Each entry provides: `{ present: bool, confidence: str|"unknown",`
+    `files: list }`.
+  - Not all detectors populate `confidence` or `files` yet; write templates to
+    degrade gracefully when values are missing.
+- Best practices:
+  - Make guidance practical and action-oriented (commands, checklists).
+  - Avoid external network fetches; link text is fine but generation must not
+    depend on network.
+  - Keep conditionals specific to avoid emitting irrelevant sections.
+  - Use lowercase tool keys; prefer portable shell snippets.
+  - Add focused unit tests under `tests/unit/templates/` that exercise your
+    template with and without relevant tools present.
+
+Example snippet:
+
+````markdown
+{% if dev_environment.tools.kubernetes %}
+### Kubernetes Deployments
+
+Define resource requests/limits and probes. Example:
+
+```yaml
+livenessProbe:
+  httpGet: { path: /healthz, port: 8080 }
+  initialDelaySeconds: 10
+  periodSeconds: 5
+```
+
+{% endif %}
+
+````
+
+<a name="code-standards"></a>
+
 ## Code Standards
 
 ### Python Code Style

--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ base.md → python.md → fastapi.md → final output
 # Results in FastAPI-specific development guidance
 ```
 
+#### Domain Templates (DevOps & MLOps)
+
+In addition to base/language/framework overlays, the generator now discovers
+and renders domain templates when matching signals are detected in your project.
+
+- DevOps: `INFRA.md`, `DEPLOYMENT.md`, `OBSERVABILITY.md`, `SECURITY.md`
+- MLOps: `MLOPS.md`, `DATA_PIPELINE.md`, `ML_GOVERNANCE.md`
+
+How it works:
+
+- Detection populates `analysis.dev_environment` (IaC, orchestration, secrets,
+  observability, CI/CD, data pipelines, MLOps tools).
+- CLAUDE.md appends any relevant domain sections automatically.
+- Templates use simple conditionals/loops, e.g.
+  `{% if dev_environment.tools.terraform %}`.
+
+Example signals → sections added to CLAUDE.md:
+
+- Terraform + Kubernetes + Helm → Infrastructure and Deployment guidance
+- Prometheus + Grafana → Observability guidance
+- MLflow + DVC + Airflow → MLOps and Data Pipeline guidance
+
 ---
 
 ## 🎯 Current Implementation Status
@@ -276,10 +298,14 @@ claude-builder /path/to/project config show
 your-project/
 ├── CLAUDE.md                    # Project-specific development guidelines
 ├── AGENTS.md                    # Intelligent agent team configuration
-└── .claude/                     # Detailed development environment
-    ├── development_workflow.md  # Optimized development processes
-    ├── agent_coordination.md    # Multi-agent collaboration patterns
-    └── project_context.md       # Complete project analysis results
+    └── .claude/                     # Detailed development environment
+        ├── development_workflow.md  # Optimized development processes
+        ├── agent_coordination.md    # Multi-agent collaboration patterns
+        └── project_context.md       # Complete project analysis results
+
+When DevOps/MLOps tools are detected, CLAUDE.md includes domain-specific
+sections with actionable guidance (infrastructure, deployment, observability,
+security, MLOps, data pipelines, and governance).
 ```
 
 ---

--- a/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
+++ b/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 {% if dev_environment.tools.kubernetes %}
 
-### Kubernetes Deployments
+## Kubernetes Deployments
 
 **Detected Tool:** Kubernetes (Confidence:
 {{ dev_environment.tools.kubernetes.confidence }})
@@ -33,7 +33,7 @@ your application to a Kubernetes cluster.
 
 {% if dev_environment.tools.helm %}
 
-### Helm Chart for Kubernetes
+## Helm Chart for Kubernetes
 
 **Detected Tool:** Helm (Confidence:
 {{ dev_environment.tools.helm.confidence }})

--- a/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
+++ b/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
@@ -1,12 +1,18 @@
+# DevOps: Deployment Guidance
+
 {% if dev_environment.tools.kubernetes %}
+
 ### Kubernetes Deployments
 
-**Detected Tool:** Kubernetes (Confidence: {{ dev_environment.tools.kubernetes.confidence }})
+**Detected Tool:** Kubernetes (Confidence:
+{{ dev_environment.tools.kubernetes.confidence }})
 
-We've detected Kubernetes configuration files, suggesting you are deploying your application to a Kubernetes cluster.
+We've detected Kubernetes configuration files, suggesting you are deploying
+your application to a Kubernetes cluster.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.kubernetes.files %}
 - {{ file }}
 {% endfor %}
@@ -14,22 +20,30 @@ We've detected Kubernetes configuration files, suggesting you are deploying your
 
 **Next Steps & Best Practices:**
 
-1.  **Use a Package Manager:** For complex applications, consider using a package manager like Helm to manage your Kubernetes resources.
-2.  **Resource Management:** Define resource requests and limits for your containers to ensure stable performance and prevent resource contention.
-3.  **Health Probes:** Implement readiness and liveness probes for your deployments to help Kubernetes manage your application's lifecycle effectively.
-4.  **Security Context:** Configure a security context for your pods and containers to restrict their permissions and enhance security.
+1. **Use a Package Manager:** For complex applications, consider using a
+   package manager like Helm to manage your Kubernetes resources.
+2. **Resource Management:** Define resource requests and limits for your
+   containers to ensure stable performance and prevent resource contention.
+3. **Health Probes:** Implement readiness and liveness probes so Kubernetes
+   can manage your application's lifecycle effectively.
+4. **Security Context:** Configure a security context for pods and containers
+   to restrict permissions and enhance security.
 
 {% endif %}
 
 {% if dev_environment.tools.helm %}
+
 ### Helm Chart for Kubernetes
 
-**Detected Tool:** Helm (Confidence: {{ dev_environment.tools.helm.confidence }})
+**Detected Tool:** Helm (Confidence:
+{{ dev_environment.tools.helm.confidence }})
 
-We've detected a Helm chart, which is a great way to package and deploy your application on Kubernetes.
+We've detected a Helm chart, which is a great way to package and deploy your
+application on Kubernetes.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.helm.files %}
 - {{ file }}
 {% endfor %}
@@ -37,14 +51,18 @@ We've detected a Helm chart, which is a great way to package and deploy your app
 
 **Next Steps & Best Practices:**
 
-1.  **Lint Your Chart:** Always run `helm lint` to catch syntax errors and ensure your chart follows best practices.
-2.  **Use Dependencies:** Manage complex applications by using subcharts and managing dependencies in your `Chart.yaml`.
-3.  **Secure Your Secrets:** Avoid storing plain-text secrets in your templates. Use a secrets management tool like HashiCorp Vault or Kubernetes Secrets.
+1. **Lint Your Chart:** Always run `helm lint` to catch syntax issues and
+   ensure your chart follows best practices.
+2. **Use Dependencies:** Manage complex applications with subcharts and
+   dependencies in `Chart.yaml`.
+3. **Secure Your Secrets:** Avoid plain-text secrets in templates. Prefer a
+   secrets management tool like Vault or Kubernetes Secrets.
 
 **Example Command:**
+
 ```bash
 # Lint your Helm chart
 helm lint ./path/to/your/chart
 ```
-{% endif %}
 
+{% endif %}

--- a/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
+++ b/src/claude_builder/templates/domains/devops/DEPLOYMENT.md
@@ -1,0 +1,50 @@
+{% if dev_environment.tools.kubernetes %}
+### Kubernetes Deployments
+
+**Detected Tool:** Kubernetes (Confidence: {{ dev_environment.tools.kubernetes.confidence }})
+
+We've detected Kubernetes configuration files, suggesting you are deploying your application to a Kubernetes cluster.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.kubernetes.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Use a Package Manager:** For complex applications, consider using a package manager like Helm to manage your Kubernetes resources.
+2.  **Resource Management:** Define resource requests and limits for your containers to ensure stable performance and prevent resource contention.
+3.  **Health Probes:** Implement readiness and liveness probes for your deployments to help Kubernetes manage your application's lifecycle effectively.
+4.  **Security Context:** Configure a security context for your pods and containers to restrict their permissions and enhance security.
+
+{% endif %}
+
+{% if dev_environment.tools.helm %}
+### Helm Chart for Kubernetes
+
+**Detected Tool:** Helm (Confidence: {{ dev_environment.tools.helm.confidence }})
+
+We've detected a Helm chart, which is a great way to package and deploy your application on Kubernetes.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.helm.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Lint Your Chart:** Always run `helm lint` to catch syntax errors and ensure your chart follows best practices.
+2.  **Use Dependencies:** Manage complex applications by using subcharts and managing dependencies in your `Chart.yaml`.
+3.  **Secure Your Secrets:** Avoid storing plain-text secrets in your templates. Use a secrets management tool like HashiCorp Vault or Kubernetes Secrets.
+
+**Example Command:**
+```bash
+# Lint your Helm chart
+helm lint ./path/to/your/chart
+```
+{% endif %}
+

--- a/src/claude_builder/templates/domains/devops/INFRA.md
+++ b/src/claude_builder/templates/domains/devops/INFRA.md
@@ -1,0 +1,28 @@
+{% if dev_environment.tools.terraform %}
+### Infrastructure as Code (IaC) with Terraform
+
+**Detected Tool:** Terraform (Confidence: {{ dev_environment.tools.terraform.confidence }})
+
+Your project appears to use Terraform for managing infrastructure as code. This is a great practice for ensuring your infrastructure is reproducible, versionable, and scalable.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.terraform.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Standardize Your Modules:** If you have multiple Terraform configurations, consider creating reusable modules to enforce consistency and reduce code duplication.
+2.  **State Management:** Ensure your Terraform state is stored in a secure, remote backend like AWS S3, Azure Blob Storage, or HashiCorp Consul, rather than in the local filesystem. This is critical for team collaboration.
+3.  **Linting and Formatting:** Use `terraform fmt -recursive` to ensure consistent formatting and `tflint` to catch common errors and enforce best practices.
+4.  **Security:** Use a tool like `tfsec` or `checkov` to scan your Terraform plans for potential security vulnerabilities before applying them.
+
+**Example Command:**
+```bash
+# Run a security scan on your Terraform code
+tfsec .
+```
+{% endif %}
+

--- a/src/claude_builder/templates/domains/devops/INFRA.md
+++ b/src/claude_builder/templates/domains/devops/INFRA.md
@@ -1,12 +1,18 @@
+# DevOps: Infrastructure Guidance
+
 {% if dev_environment.tools.terraform %}
+
 ### Infrastructure as Code (IaC) with Terraform
 
-**Detected Tool:** Terraform (Confidence: {{ dev_environment.tools.terraform.confidence }})
+**Detected Tool:** Terraform (Confidence:
+{{ dev_environment.tools.terraform.confidence }})
 
-Your project appears to use Terraform for managing infrastructure as code. This is a great practice for ensuring your infrastructure is reproducible, versionable, and scalable.
+Your project appears to use Terraform for managing infrastructure as code. This
+helps ensure infrastructure is reproducible, versionable, and scalable.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.terraform.files %}
 - {{ file }}
 {% endfor %}
@@ -14,15 +20,20 @@ Your project appears to use Terraform for managing infrastructure as code. This 
 
 **Next Steps & Best Practices:**
 
-1.  **Standardize Your Modules:** If you have multiple Terraform configurations, consider creating reusable modules to enforce consistency and reduce code duplication.
-2.  **State Management:** Ensure your Terraform state is stored in a secure, remote backend like AWS S3, Azure Blob Storage, or HashiCorp Consul, rather than in the local filesystem. This is critical for team collaboration.
-3.  **Linting and Formatting:** Use `terraform fmt -recursive` to ensure consistent formatting and `tflint` to catch common errors and enforce best practices.
-4.  **Security:** Use a tool like `tfsec` or `checkov` to scan your Terraform plans for potential security vulnerabilities before applying them.
+1. **Standardize Modules:** If you have multiple configurations, create
+   reusable modules to enforce consistency and reduce duplication.
+2. **State Management:** Store state in a secure, remote backend (for example
+   S3, Azure Blob, or Terraform Cloud), not locally. This is critical for team
+   collaboration.
+3. **Linting and Formatting:** Use `terraform fmt -recursive` for formatting and
+   `tflint` to catch common errors and enforce best practices.
+4. **Security:** Scan plans with `tfsec` or `checkov` before applying changes.
 
 **Example Command:**
+
 ```bash
 # Run a security scan on your Terraform code
 tfsec .
 ```
-{% endif %}
 
+{% endif %}

--- a/src/claude_builder/templates/domains/devops/INFRA.md
+++ b/src/claude_builder/templates/domains/devops/INFRA.md
@@ -2,7 +2,7 @@
 
 {% if dev_environment.tools.terraform %}
 
-### Infrastructure as Code (IaC) with Terraform
+## Infrastructure as Code (IaC) with Terraform
 
 **Detected Tool:** Terraform (Confidence:
 {{ dev_environment.tools.terraform.confidence }})

--- a/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
+++ b/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
@@ -2,7 +2,7 @@
 
 {% if dev_environment.tools.prometheus %}
 
-### Prometheus Monitoring
+## Prometheus Monitoring
 
 **Detected Tool:** Prometheus (Confidence:
 {{ dev_environment.tools.prometheus.confidence }})
@@ -30,7 +30,7 @@ monitoring.
 
 {% if dev_environment.tools.grafana %}
 
-### Grafana Dashboards
+## Grafana Dashboards
 
 **Detected Tool:** Grafana (Confidence:
 {{ dev_environment.tools.grafana.confidence }})
@@ -57,7 +57,7 @@ system behavior.
 
 {% if dev_environment.tools.opentelemetry %}
 
-### OpenTelemetry Tracing
+## OpenTelemetry Tracing
 
 **Detected Tool:** OpenTelemetry (Confidence:
 {{ dev_environment.tools.opentelemetry.confidence }})

--- a/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
+++ b/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
@@ -1,0 +1,59 @@
+{% if dev_environment.tools.prometheus %}
+### Prometheus Monitoring
+
+**Detected Tool:** Prometheus (Confidence: {{ dev_environment.tools.prometheus.confidence }})
+
+Prometheus configuration files were found, indicating that you are using Prometheus for monitoring.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.prometheus.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Instrument Your Application:** Expose custom application metrics for Prometheus to scrape. This will give you deeper insights into your application's performance.
+2.  **Alerting Rules:** Define alerting rules in Prometheus to be notified of important events.
+3.  **Use a Dashboard:** Visualize your metrics with a tool like Grafana for easier analysis.
+
+{% endif %}
+
+{% if dev_environment.tools.grafana %}
+### Grafana Dashboards
+
+**Detected Tool:** Grafana (Confidence: {{ dev_environment.tools.grafana.confidence }})
+
+We've detected Grafana dashboard configurations. Visualizing your metrics is key to understanding your system's behavior.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.grafana.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Version Your Dashboards:** Store your dashboard JSON files in version control to track changes and collaborate with your team.
+2.  **Use Variables:** Make your dashboards more interactive and reusable by using template variables.
+3.  **Organize with Folders:** Group related dashboards into folders to keep your Grafana instance organized.
+
+{% endif %}
+
+{% if dev_environment.tools.opentelemetry %}
+### OpenTelemetry Tracing
+
+**Detected Tool:** OpenTelemetry (Confidence: {{ dev_environment.tools.opentelemetry.confidence }})
+
+OpenTelemetry usage has been detected. Distributed tracing is a powerful tool for debugging and understanding your application's performance in a microservices architecture.
+
+**Next Steps & Best Practices:**
+
+1.  **Ensure Consistent Sampling:** Configure your sampling strategy to capture a representative amount of traces without overwhelming your system.
+2.  **Propagate Context:** Make sure trace context is propagated across all your services to get a complete end-to-end view of your requests.
+3.  **Add Custom Attributes:** Enrich your spans with custom attributes to provide more context and make debugging easier.
+
+{% endif %}
+

--- a/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
+++ b/src/claude_builder/templates/domains/devops/OBSERVABILITY.md
@@ -1,12 +1,18 @@
+# DevOps: Observability Guidance
+
 {% if dev_environment.tools.prometheus %}
+
 ### Prometheus Monitoring
 
-**Detected Tool:** Prometheus (Confidence: {{ dev_environment.tools.prometheus.confidence }})
+**Detected Tool:** Prometheus (Confidence:
+{{ dev_environment.tools.prometheus.confidence }})
 
-Prometheus configuration files were found, indicating that you are using Prometheus for monitoring.
+Prometheus configuration files were found, indicating you are using it for
+monitoring.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.prometheus.files %}
 - {{ file }}
 {% endfor %}
@@ -14,21 +20,27 @@ Prometheus configuration files were found, indicating that you are using Prometh
 
 **Next Steps & Best Practices:**
 
-1.  **Instrument Your Application:** Expose custom application metrics for Prometheus to scrape. This will give you deeper insights into your application's performance.
-2.  **Alerting Rules:** Define alerting rules in Prometheus to be notified of important events.
-3.  **Use a Dashboard:** Visualize your metrics with a tool like Grafana for easier analysis.
+1. **Instrument Your Application:** Expose custom metrics for Prometheus to
+   scrape to gain insight into performance and behavior.
+2. **Alerting Rules:** Define alerting rules to be notified of important
+   events.
+3. **Dashboards:** Visualize metrics in Grafana for faster analysis.
 
 {% endif %}
 
 {% if dev_environment.tools.grafana %}
+
 ### Grafana Dashboards
 
-**Detected Tool:** Grafana (Confidence: {{ dev_environment.tools.grafana.confidence }})
+**Detected Tool:** Grafana (Confidence:
+{{ dev_environment.tools.grafana.confidence }})
 
-We've detected Grafana dashboard configurations. Visualizing your metrics is key to understanding your system's behavior.
+We detected Grafana configurations. Visualizing metrics helps you understand
+system behavior.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.grafana.files %}
 - {{ file }}
 {% endfor %}
@@ -36,24 +48,27 @@ We've detected Grafana dashboard configurations. Visualizing your metrics is key
 
 **Next Steps & Best Practices:**
 
-1.  **Version Your Dashboards:** Store your dashboard JSON files in version control to track changes and collaborate with your team.
-2.  **Use Variables:** Make your dashboards more interactive and reusable by using template variables.
-3.  **Organize with Folders:** Group related dashboards into folders to keep your Grafana instance organized.
+1. **Version Dashboards:** Store dashboard JSON in version control to track
+   changes.
+2. **Use Variables:** Make dashboards reusable and interactive with variables.
+3. **Organize:** Group related dashboards into folders to keep things tidy.
 
 {% endif %}
 
 {% if dev_environment.tools.opentelemetry %}
+
 ### OpenTelemetry Tracing
 
-**Detected Tool:** OpenTelemetry (Confidence: {{ dev_environment.tools.opentelemetry.confidence }})
+**Detected Tool:** OpenTelemetry (Confidence:
+{{ dev_environment.tools.opentelemetry.confidence }})
 
-OpenTelemetry usage has been detected. Distributed tracing is a powerful tool for debugging and understanding your application's performance in a microservices architecture.
+Distributed tracing helps debug and understand performance across services.
 
 **Next Steps & Best Practices:**
 
-1.  **Ensure Consistent Sampling:** Configure your sampling strategy to capture a representative amount of traces without overwhelming your system.
-2.  **Propagate Context:** Make sure trace context is propagated across all your services to get a complete end-to-end view of your requests.
-3.  **Add Custom Attributes:** Enrich your spans with custom attributes to provide more context and make debugging easier.
+1. **Sampling:** Configure sampling to balance visibility and overhead.
+2. **Context Propagation:** Ensure trace context is propagated across all
+   services.
+3. **Custom Attributes:** Enrich spans with attributes for better debugging.
 
 {% endif %}
-

--- a/src/claude_builder/templates/domains/devops/SECURITY.md
+++ b/src/claude_builder/templates/domains/devops/SECURITY.md
@@ -1,0 +1,45 @@
+{% if dev_environment.tools.vault %}
+### HashiCorp Vault for Secrets Management
+
+**Detected Tool:** Vault (Confidence: {{ dev_environment.tools.vault.confidence }})
+
+We've detected usage of HashiCorp Vault, which is an excellent choice for managing secrets and protecting sensitive data.
+
+**Next Steps & Best Practices:**
+
+1.  **Use Dynamic Secrets:** Whenever possible, use Vault's dynamic secrets to generate credentials on-demand. This reduces the risk of leaked static secrets.
+2.  **Audit Trails:** Ensure that you have enabled audit devices to maintain a detailed log of all requests and responses to Vault.
+3.  **Fine-Grained Policies:** Implement fine-grained access control policies to ensure that applications and users only have access to the secrets they need.
+
+{% endif %}
+
+{% if dev_environment.tools.tfsec %}
+### tfsec for Terraform Security
+
+**Detected Tool:** tfsec (Confidence: {{ dev_environment.tools.tfsec.confidence }})
+
+tfsec is being used to scan your Terraform code for security vulnerabilities. This is a great way to shift security left and catch issues early.
+
+**Next Steps & Best Practices:**
+
+1.  **Integrate into CI/CD:** Run `tfsec` as a step in your CI/CD pipeline to automatically scan every pull request.
+2.  **Customize Policies:** If needed, you can customize the checks that `tfsec` performs by using a custom configuration file.
+3.  **Regularly Update:** Keep `tfsec` updated to the latest version to benefit from new checks and security vulnerability disclosures.
+
+{% endif %}
+
+{% if dev_environment.tools.trivy %}
+### Trivy for Vulnerability Scanning
+
+**Detected Tool:** Trivy (Confidence: {{ dev_environment.tools.trivy.confidence }})
+
+Trivy is being used for vulnerability scanning. This is a crucial step in securing your container images and other artifacts.
+
+**Next Steps & Best Practices:**
+
+1.  **Scan in CI/CD:** Integrate Trivy into your CI/CD pipeline to scan your container images before they are pushed to a registry.
+2.  **Scan Filesystems and Git Repositories:** In addition to container images, you can use Trivy to scan your application's filesystem and Git repository for vulnerabilities in your dependencies.
+3.  **Filter Vulnerabilities:** Use a `.trivyignore` file to filter out vulnerabilities that are not relevant to your project.
+
+{% endif %}
+

--- a/src/claude_builder/templates/domains/devops/SECURITY.md
+++ b/src/claude_builder/templates/domains/devops/SECURITY.md
@@ -2,7 +2,7 @@
 
 {% if dev_environment.tools.vault %}
 
-### HashiCorp Vault for Secrets Management
+## HashiCorp Vault for Secrets Management
 
 **Detected Tool:** Vault (Confidence:
 {{ dev_environment.tools.vault.confidence }})
@@ -22,7 +22,7 @@ Vault helps manage secrets and protect sensitive data.
 
 {% if dev_environment.tools.tfsec %}
 
-### tfsec for Terraform Security
+## tfsec for Terraform Security
 
 **Detected Tool:** tfsec (Confidence:
 {{ dev_environment.tools.tfsec.confidence }})
@@ -39,7 +39,7 @@ tfsec scans Terraform code for security issues.
 
 {% if dev_environment.tools.trivy %}
 
-### Trivy for Vulnerability Scanning
+## Trivy for Vulnerability Scanning
 
 **Detected Tool:** Trivy (Confidence:
 {{ dev_environment.tools.trivy.confidence }})

--- a/src/claude_builder/templates/domains/devops/SECURITY.md
+++ b/src/claude_builder/templates/domains/devops/SECURITY.md
@@ -1,45 +1,55 @@
+# DevOps: Security Guidance
+
 {% if dev_environment.tools.vault %}
+
 ### HashiCorp Vault for Secrets Management
 
-**Detected Tool:** Vault (Confidence: {{ dev_environment.tools.vault.confidence }})
+**Detected Tool:** Vault (Confidence:
+{{ dev_environment.tools.vault.confidence }})
 
-We've detected usage of HashiCorp Vault, which is an excellent choice for managing secrets and protecting sensitive data.
+Vault helps manage secrets and protect sensitive data.
 
 **Next Steps & Best Practices:**
 
-1.  **Use Dynamic Secrets:** Whenever possible, use Vault's dynamic secrets to generate credentials on-demand. This reduces the risk of leaked static secrets.
-2.  **Audit Trails:** Ensure that you have enabled audit devices to maintain a detailed log of all requests and responses to Vault.
-3.  **Fine-Grained Policies:** Implement fine-grained access control policies to ensure that applications and users only have access to the secrets they need.
+1. **Use Dynamic Secrets:** Prefer dynamic credentials to reduce the risk of
+   leaked static secrets.
+2. **Audit Trails:** Enable audit devices to maintain detailed logs of all
+   requests and responses to Vault.
+3. **Fine-Grained Policies:** Implement policies to ensure apps and users only
+   access what they need.
 
 {% endif %}
 
 {% if dev_environment.tools.tfsec %}
+
 ### tfsec for Terraform Security
 
-**Detected Tool:** tfsec (Confidence: {{ dev_environment.tools.tfsec.confidence }})
+**Detected Tool:** tfsec (Confidence:
+{{ dev_environment.tools.tfsec.confidence }})
 
-tfsec is being used to scan your Terraform code for security vulnerabilities. This is a great way to shift security left and catch issues early.
+tfsec scans Terraform code for security issues.
 
 **Next Steps & Best Practices:**
 
-1.  **Integrate into CI/CD:** Run `tfsec` as a step in your CI/CD pipeline to automatically scan every pull request.
-2.  **Customize Policies:** If needed, you can customize the checks that `tfsec` performs by using a custom configuration file.
-3.  **Regularly Update:** Keep `tfsec` updated to the latest version to benefit from new checks and security vulnerability disclosures.
+1. **CI/CD Integration:** Run `tfsec` in CI to scan every pull request.
+2. **Customize Policies:** Adjust checks via a configuration file when needed.
+3. **Stay Updated:** Keep `tfsec` current to benefit from new rules.
 
 {% endif %}
 
 {% if dev_environment.tools.trivy %}
+
 ### Trivy for Vulnerability Scanning
 
-**Detected Tool:** Trivy (Confidence: {{ dev_environment.tools.trivy.confidence }})
+**Detected Tool:** Trivy (Confidence:
+{{ dev_environment.tools.trivy.confidence }})
 
-Trivy is being used for vulnerability scanning. This is a crucial step in securing your container images and other artifacts.
+Trivy scans container images and filesystems for vulnerabilities.
 
 **Next Steps & Best Practices:**
 
-1.  **Scan in CI/CD:** Integrate Trivy into your CI/CD pipeline to scan your container images before they are pushed to a registry.
-2.  **Scan Filesystems and Git Repositories:** In addition to container images, you can use Trivy to scan your application's filesystem and Git repository for vulnerabilities in your dependencies.
-3.  **Filter Vulnerabilities:** Use a `.trivyignore` file to filter out vulnerabilities that are not relevant to your project.
+1. **Scan in CI/CD:** Scan images before pushing to a registry.
+2. **Scan Filesystems and Repos:** Use Trivy on app files and dependencies.
+3. **Filter Noise:** Use `.trivyignore` for irrelevant findings.
 
 {% endif %}
-

--- a/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
+++ b/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
@@ -1,6 +1,8 @@
+# MLOps: Data Pipeline Guidance
+
 {% if dev_environment.tools.airflow %}
 
-### Airflow for Data Pipelines
+## Airflow for Data Pipelines
 
 **Detected Tool:** Airflow (Confidence:
 {{ dev_environment.tools.airflow.confidence }})
@@ -25,7 +27,7 @@ Airflow is a platform for authoring, scheduling, and monitoring workflows.
 
 {% if dev_environment.tools.prefect %}
 
-### Prefect for Data Pipelines
+## Prefect for Data Pipelines
 
 **Detected Tool:** Prefect (Confidence:
 {{ dev_environment.tools.prefect.confidence }})
@@ -42,7 +44,7 @@ Prefect is a modern workflow automation platform.
 
 {% if dev_environment.tools.dagster %}
 
-### Dagster for Data Pipelines
+## Dagster for Data Pipelines
 
 **Detected Tool:** Dagster (Confidence:
 {{ dev_environment.tools.dagster.confidence }})
@@ -59,7 +61,7 @@ Dagster orchestrates ML, analytics, and ETL assets.
 
 {% if dev_environment.tools.dvc %}
 
-### DVC for Data Versioning
+## DVC for Data Versioning
 
 **Detected Tool:** DVC (Confidence:
 {{ dev_environment.tools.dvc.confidence }})

--- a/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
+++ b/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
@@ -1,12 +1,15 @@
 {% if dev_environment.tools.airflow %}
+
 ### Airflow for Data Pipelines
 
-**Detected Tool:** Airflow (Confidence: {{ dev_environment.tools.airflow.confidence }})
+**Detected Tool:** Airflow (Confidence:
+{{ dev_environment.tools.airflow.confidence }})
 
-Airflow DAGs have been detected. Airflow is a robust platform for programmatically authoring, scheduling, and monitoring workflows.
+Airflow is a platform for authoring, scheduling, and monitoring workflows.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.airflow.files %}
 - {{ file }}
 {% endfor %}
@@ -14,51 +17,58 @@ Airflow DAGs have been detected. Airflow is a robust platform for programmatical
 
 **Next Steps & Best Practices:**
 
-1.  **Use TaskFlow API:** For new DAGs, consider using the TaskFlow API to write your pipelines in a more Python-native way.
-2.  **Keep Tasks Atomic:** Design your tasks to be atomic and idempotent to make your DAGs more resilient and easier to debug.
-3.  **Use a Version Control System:** Store your DAGs in a version control system like Git to track changes and collaborate with your team.
+1. **TaskFlow API:** Prefer TaskFlow for Python‑native DAGs.
+2. **Atomic Tasks:** Design tasks to be atomic and idempotent.
+3. **Version Control:** Store DAGs in Git to track changes.
 
 {% endif %}
 
 {% if dev_environment.tools.prefect %}
+
 ### Prefect for Data Pipelines
 
-**Detected Tool:** Prefect (Confidence: {{ dev_environment.tools.prefect.confidence }})
+**Detected Tool:** Prefect (Confidence:
+{{ dev_environment.tools.prefect.confidence }})
 
-Prefect flows have been detected. Prefect is a modern data workflow automation platform.
+Prefect is a modern workflow automation platform.
 
 **Next Steps & Best Practices:**
 
-1.  **Use a Backend:** Configure a backend (Prefect Cloud or a self-hosted server) to orchestrate and monitor your flows.
-2.  **Use Caching:** Use Prefect's caching mechanism to avoid re-running tasks that have already completed successfully.
-3.  **Organize with Projects:** Group related flows into projects to keep your work organized.
+1. **Backend:** Use Prefect Cloud or a self‑hosted server.
+2. **Caching:** Enable caching to avoid repeated work.
+3. **Projects:** Group related flows into projects.
 
 {% endif %}
 
 {% if dev_environment.tools.dagster %}
+
 ### Dagster for Data Pipelines
 
-**Detected Tool:** Dagster (Confidence: {{ dev_environment.tools.dagster.confidence }})
+**Detected Tool:** Dagster (Confidence:
+{{ dev_environment.tools.dagster.confidence }})
 
-Dagster assets have been detected. Dagster is a data orchestrator for machine learning, analytics, and ETL.
+Dagster orchestrates ML, analytics, and ETL assets.
 
 **Next Steps & Best Practices:**
 
-1.  **Use Software-Defined Assets:** Define your data assets in code to provide a single source of truth for your data platform.
-2.  **Use I/O Managers:** Use I/O managers to abstract away the storage and loading of your assets.
-3.  **Use Dagit:** Use the Dagit UI to visualize your assets, monitor runs, and debug your pipelines.
+1. **Software‑Defined Assets:** Define assets in code as the source of truth.
+2. **I/O Managers:** Abstract storage/loading with I/O managers.
+3. **Dagit:** Use Dagit for visualization and debugging.
 
 {% endif %}
 
 {% if dev_environment.tools.dvc %}
+
 ### DVC for Data Versioning
 
-**Detected Tool:** DVC (Confidence: {{ dev_environment.tools.dvc.confidence }})
+**Detected Tool:** DVC (Confidence:
+{{ dev_environment.tools.dvc.confidence }})
 
-DVC files have been detected. DVC is a great tool for versioning your data and models.
+DVC versions data and models.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.dvc.files %}
 - {{ file }}
 {% endfor %}
@@ -66,9 +76,8 @@ DVC files have been detected. DVC is a great tool for versioning your data and m
 
 **Next Steps & Best Practices:**
 
-1.  **Use a Remote Storage:** Configure a remote storage (like S3, GCS, or a shared network drive) to share your data and models with your team.
-2.  **Use Pipelines:** Use DVC pipelines to define your data processing and modeling workflows.
-3.  **Track Metrics:** Use DVC to track metrics and compare the performance of different experiments.
+1. **Remote Storage:** Configure a remote (S3, GCS, etc.) for sharing.
+2. **Pipelines:** Define processing and modeling pipelines in DVC.
+3. **Track Metrics:** Track and compare experiment metrics.
 
 {% endif %}
-

--- a/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
+++ b/src/claude_builder/templates/domains/mlops/DATA_PIPELINE.md
@@ -1,0 +1,74 @@
+{% if dev_environment.tools.airflow %}
+### Airflow for Data Pipelines
+
+**Detected Tool:** Airflow (Confidence: {{ dev_environment.tools.airflow.confidence }})
+
+Airflow DAGs have been detected. Airflow is a robust platform for programmatically authoring, scheduling, and monitoring workflows.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.airflow.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Use TaskFlow API:** For new DAGs, consider using the TaskFlow API to write your pipelines in a more Python-native way.
+2.  **Keep Tasks Atomic:** Design your tasks to be atomic and idempotent to make your DAGs more resilient and easier to debug.
+3.  **Use a Version Control System:** Store your DAGs in a version control system like Git to track changes and collaborate with your team.
+
+{% endif %}
+
+{% if dev_environment.tools.prefect %}
+### Prefect for Data Pipelines
+
+**Detected Tool:** Prefect (Confidence: {{ dev_environment.tools.prefect.confidence }})
+
+Prefect flows have been detected. Prefect is a modern data workflow automation platform.
+
+**Next Steps & Best Practices:**
+
+1.  **Use a Backend:** Configure a backend (Prefect Cloud or a self-hosted server) to orchestrate and monitor your flows.
+2.  **Use Caching:** Use Prefect's caching mechanism to avoid re-running tasks that have already completed successfully.
+3.  **Organize with Projects:** Group related flows into projects to keep your work organized.
+
+{% endif %}
+
+{% if dev_environment.tools.dagster %}
+### Dagster for Data Pipelines
+
+**Detected Tool:** Dagster (Confidence: {{ dev_environment.tools.dagster.confidence }})
+
+Dagster assets have been detected. Dagster is a data orchestrator for machine learning, analytics, and ETL.
+
+**Next Steps & Best Practices:**
+
+1.  **Use Software-Defined Assets:** Define your data assets in code to provide a single source of truth for your data platform.
+2.  **Use I/O Managers:** Use I/O managers to abstract away the storage and loading of your assets.
+3.  **Use Dagit:** Use the Dagit UI to visualize your assets, monitor runs, and debug your pipelines.
+
+{% endif %}
+
+{% if dev_environment.tools.dvc %}
+### DVC for Data Versioning
+
+**Detected Tool:** DVC (Confidence: {{ dev_environment.tools.dvc.confidence }})
+
+DVC files have been detected. DVC is a great tool for versioning your data and models.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.dvc.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Use a Remote Storage:** Configure a remote storage (like S3, GCS, or a shared network drive) to share your data and models with your team.
+2.  **Use Pipelines:** Use DVC pipelines to define your data processing and modeling workflows.
+3.  **Track Metrics:** Use DVC to track metrics and compare the performance of different experiments.
+
+{% endif %}
+

--- a/src/claude_builder/templates/domains/mlops/MLOPS.md
+++ b/src/claude_builder/templates/domains/mlops/MLOPS.md
@@ -1,0 +1,37 @@
+{% if dev_environment.tools.mlflow %}
+### MLflow for MLOps
+
+**Detected Tool:** MLflow (Confidence: {{ dev_environment.tools.mlflow.confidence }})
+
+MLflow usage has been detected. MLflow is a great open-source platform for managing the end-to-end machine learning lifecycle.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.mlflow.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Use a Tracking Server:** For collaborative projects, set up a central MLflow Tracking Server to log and compare experiments.
+2.  **Log Artifacts:** In addition to metrics and parameters, log artifacts such as models, data files, and images to ensure reproducibility.
+3.  **Model Registry:** Use the MLflow Model Registry to manage your model's lifecycle from staging to production.
+
+{% endif %}
+
+{% if dev_environment.tools.kubeflow %}
+### Kubeflow for MLOps on Kubernetes
+
+**Detected Tool:** Kubeflow (Confidence: {{ dev_environment.tools.kubeflow.confidence }})
+
+We've detected Kubeflow configuration files. Kubeflow is a powerful platform for deploying and managing machine learning workflows on Kubernetes.
+
+**Next Steps & Best Practices:**
+
+1.  **Use Pipelines:** Define your ML workflows as pipelines to make them reproducible, scalable, and easy to manage.
+2.  **Leverage Components:** Create reusable components to share and reuse parts of your ML workflows.
+3.  **Katib for Hyperparameter Tuning:** Use Katib to automate hyperparameter tuning and find the best model for your problem.
+
+{% endif %}
+

--- a/src/claude_builder/templates/domains/mlops/MLOPS.md
+++ b/src/claude_builder/templates/domains/mlops/MLOPS.md
@@ -1,12 +1,15 @@
 {% if dev_environment.tools.mlflow %}
+
 ### MLflow for MLOps
 
-**Detected Tool:** MLflow (Confidence: {{ dev_environment.tools.mlflow.confidence }})
+**Detected Tool:** MLflow (Confidence:
+{{ dev_environment.tools.mlflow.confidence }})
 
-MLflow usage has been detected. MLflow is a great open-source platform for managing the end-to-end machine learning lifecycle.
+MLflow manages the end‑to‑end machine learning lifecycle.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.mlflow.files %}
 - {{ file }}
 {% endfor %}
@@ -14,24 +17,30 @@ MLflow usage has been detected. MLflow is a great open-source platform for manag
 
 **Next Steps & Best Practices:**
 
-1.  **Use a Tracking Server:** For collaborative projects, set up a central MLflow Tracking Server to log and compare experiments.
-2.  **Log Artifacts:** In addition to metrics and parameters, log artifacts such as models, data files, and images to ensure reproducibility.
-3.  **Model Registry:** Use the MLflow Model Registry to manage your model's lifecycle from staging to production.
+1. **Use a Tracking Server:** For collaboration, set up a central Tracking
+   Server to log and compare experiments.
+2. **Log Artifacts:** Log models, data, and images in addition to metrics and
+   parameters to ensure reproducibility.
+3. **Model Registry:** Manage lifecycle from staging to production with the
+   Model Registry.
 
 {% endif %}
 
 {% if dev_environment.tools.kubeflow %}
+
 ### Kubeflow for MLOps on Kubernetes
 
-**Detected Tool:** Kubeflow (Confidence: {{ dev_environment.tools.kubeflow.confidence }})
+**Detected Tool:** Kubeflow (Confidence:
+{{ dev_environment.tools.kubeflow.confidence }})
 
-We've detected Kubeflow configuration files. Kubeflow is a powerful platform for deploying and managing machine learning workflows on Kubernetes.
+Kubeflow helps deploy and manage ML workflows on Kubernetes.
 
 **Next Steps & Best Practices:**
 
-1.  **Use Pipelines:** Define your ML workflows as pipelines to make them reproducible, scalable, and easy to manage.
-2.  **Leverage Components:** Create reusable components to share and reuse parts of your ML workflows.
-3.  **Katib for Hyperparameter Tuning:** Use Katib to automate hyperparameter tuning and find the best model for your problem.
+1. **Pipelines:** Define ML workflows as pipelines to make them reproducible
+   and scalable.
+2. **Components:** Create reusable components to share workflow building
+   blocks.
+3. **Katib:** Use Katib for automated hyperparameter tuning.
 
 {% endif %}
-

--- a/src/claude_builder/templates/domains/mlops/MLOPS.md
+++ b/src/claude_builder/templates/domains/mlops/MLOPS.md
@@ -1,6 +1,8 @@
+# MLOps: Lifecycle Guidance
+
 {% if dev_environment.tools.mlflow %}
 
-### MLflow for MLOps
+## MLflow for MLOps
 
 **Detected Tool:** MLflow (Confidence:
 {{ dev_environment.tools.mlflow.confidence }})
@@ -28,7 +30,7 @@ MLflow manages the end‑to‑end machine learning lifecycle.
 
 {% if dev_environment.tools.kubeflow %}
 
-### Kubeflow for MLOps on Kubernetes
+## Kubeflow for MLOps on Kubernetes
 
 **Detected Tool:** Kubeflow (Confidence:
 {{ dev_environment.tools.kubeflow.confidence }})

--- a/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
+++ b/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
@@ -1,12 +1,15 @@
 {% if dev_environment.tools.dbt %}
+
 ### dbt for Data Transformation
 
-**Detected Tool:** dbt (Confidence: {{ dev_environment.tools.dbt.confidence }})
+**Detected Tool:** dbt (Confidence:
+{{ dev_environment.tools.dbt.confidence }})
 
-dbt models have been detected. dbt is a great tool for transforming data in your warehouse.
+dbt transforms data in your warehouse using SQL and tested models.
 
 **Key Files Detected:**
-```
+
+```text
 {% for file in dev_environment.tools.dbt.files %}
 - {{ file }}
 {% endfor %}
@@ -14,39 +17,43 @@ dbt models have been detected. dbt is a great tool for transforming data in your
 
 **Next Steps & Best Practices:**
 
-1.  **Test Your Models:** Write tests for your dbt models to ensure data quality and prevent regressions.
-2.  **Document Your Models:** Document your models to help your team understand your data warehouse.
-3.  **Use Packages:** Leverage dbt packages to reuse code and speed up your development.
+1. **Tests:** Write tests to ensure data quality and prevent regressions.
+2. **Docs:** Document models to help teams understand your warehouse.
+3. **Packages:** Reuse code via dbt packages to speed development.
 
 {% endif %}
 
 {% if dev_environment.tools.great_expectations %}
+
 ### Great Expectations for Data Quality
 
-**Detected Tool:** Great Expectations (Confidence: {{ dev_environment.tools.great_expectations.confidence }})
+**Detected Tool:** Great Expectations (Confidence:
+{{ dev_environment.tools.great_expectations.confidence }})
 
-Great Expectations checkpoints have been detected. Great Expectations is a powerful tool for data testing, documentation, and profiling.
+Great Expectations provides data testing, documentation, and profiling.
 
 **Next Steps & Best Practices:**
 
-1.  **Integrate into Pipelines:** Run your checkpoints as part of your data pipelines to automatically validate your data.
-2.  **Use Data Docs:** Host and share your Data Docs to provide a single source of truth for your data quality.
-3.  **Customize Expectations:** Write custom Expectations to meet your specific data quality needs.
+1. **Pipelines:** Run checkpoints in pipelines to validate data.
+2. **Data Docs:** Host Data Docs as the single source of truth.
+3. **Custom Expectations:** Write custom checks for your needs.
 
 {% endif %}
 
 {% if dev_environment.tools.feast %}
+
 ### Feast for Feature Stores
 
-**Detected Tool:** Feast (Confidence: {{ dev_environment.tools.feast.confidence }})
+**Detected Tool:** Feast (Confidence:
+{{ dev_environment.tools.feast.confidence }})
 
-Feast feature definitions have been detected. Feast is an open-source feature store for machine learning.
+Feast is a feature store for machine learning.
 
 **Next Steps & Best Practices:**
 
-1.  **Use a Centralized Store:** Use a centralized online and offline store to serve features for both training and inference.
-2.  **Monitor Feature Drift:** Monitor your features for drift to ensure that your models are not trained on stale or irrelevant data.
-3.  **Share and Reuse Features:** Use Feast to share and reuse features across multiple projects and teams.
+1. **Centralized Store:** Provide combined online/offline stores for training
+   and inference.
+2. **Monitor Drift:** Watch features for drift to avoid stale inputs.
+3. **Share/Reuse:** Share features across projects and teams.
 
 {% endif %}
-

--- a/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
+++ b/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
@@ -1,0 +1,52 @@
+{% if dev_environment.tools.dbt %}
+### dbt for Data Transformation
+
+**Detected Tool:** dbt (Confidence: {{ dev_environment.tools.dbt.confidence }})
+
+dbt models have been detected. dbt is a great tool for transforming data in your warehouse.
+
+**Key Files Detected:**
+```
+{% for file in dev_environment.tools.dbt.files %}
+- {{ file }}
+{% endfor %}
+```
+
+**Next Steps & Best Practices:**
+
+1.  **Test Your Models:** Write tests for your dbt models to ensure data quality and prevent regressions.
+2.  **Document Your Models:** Document your models to help your team understand your data warehouse.
+3.  **Use Packages:** Leverage dbt packages to reuse code and speed up your development.
+
+{% endif %}
+
+{% if dev_environment.tools.great_expectations %}
+### Great Expectations for Data Quality
+
+**Detected Tool:** Great Expectations (Confidence: {{ dev_environment.tools.great_expectations.confidence }})
+
+Great Expectations checkpoints have been detected. Great Expectations is a powerful tool for data testing, documentation, and profiling.
+
+**Next Steps & Best Practices:**
+
+1.  **Integrate into Pipelines:** Run your checkpoints as part of your data pipelines to automatically validate your data.
+2.  **Use Data Docs:** Host and share your Data Docs to provide a single source of truth for your data quality.
+3.  **Customize Expectations:** Write custom Expectations to meet your specific data quality needs.
+
+{% endif %}
+
+{% if dev_environment.tools.feast %}
+### Feast for Feature Stores
+
+**Detected Tool:** Feast (Confidence: {{ dev_environment.tools.feast.confidence }})
+
+Feast feature definitions have been detected. Feast is an open-source feature store for machine learning.
+
+**Next Steps & Best Practices:**
+
+1.  **Use a Centralized Store:** Use a centralized online and offline store to serve features for both training and inference.
+2.  **Monitor Feature Drift:** Monitor your features for drift to ensure that your models are not trained on stale or irrelevant data.
+3.  **Share and Reuse Features:** Use Feast to share and reuse features across multiple projects and teams.
+
+{% endif %}
+

--- a/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
+++ b/src/claude_builder/templates/domains/mlops/ML_GOVERNANCE.md
@@ -1,6 +1,8 @@
+# MLOps: Governance Guidance
+
 {% if dev_environment.tools.dbt %}
 
-### dbt for Data Transformation
+## dbt for Data Transformation
 
 **Detected Tool:** dbt (Confidence:
 {{ dev_environment.tools.dbt.confidence }})
@@ -25,7 +27,7 @@ dbt transforms data in your warehouse using SQL and tested models.
 
 {% if dev_environment.tools.great_expectations %}
 
-### Great Expectations for Data Quality
+## Great Expectations for Data Quality
 
 **Detected Tool:** Great Expectations (Confidence:
 {{ dev_environment.tools.great_expectations.confidence }})
@@ -42,7 +44,7 @@ Great Expectations provides data testing, documentation, and profiling.
 
 {% if dev_environment.tools.feast %}
 
-### Feast for Feature Stores
+## Feast for Feature Stores
 
 **Detected Tool:** Feast (Confidence:
 {{ dev_environment.tools.feast.confidence }})

--- a/tests/unit/templates/test_domain_templates.py
+++ b/tests/unit/templates/test_domain_templates.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from claude_builder.core.models import (
+    ComplexityLevel,
+    FrameworkInfo,
+    LanguageInfo,
+    ProjectAnalysis,
+    ProjectType,
+)
+from claude_builder.core.template_manager import ModernTemplateManager
+
+
+def _make_analysis(tmp_path: Path, *, tools: dict[str, list[str]]) -> ProjectAnalysis:
+    analysis = ProjectAnalysis(
+        project_path=tmp_path / "sample",
+        language_info=LanguageInfo(primary="python", confidence=95.0),
+        framework_info=FrameworkInfo(primary=None, confidence=0.0),
+        project_type=ProjectType.API_SERVICE,
+        complexity_level=ComplexityLevel.MODERATE,
+    )
+    analysis.project_path.mkdir(parents=True, exist_ok=True)
+    env = analysis.dev_environment
+    env.infrastructure_as_code = tools.get("infrastructure_as_code", [])
+    env.orchestration_tools = tools.get("orchestration_tools", [])
+    env.secrets_management = tools.get("secrets_management", [])
+    env.observability = tools.get("observability", [])
+    env.ci_cd_systems = tools.get("ci_cd_systems", [])
+    env.data_pipeline = tools.get("data_pipeline", [])
+    env.mlops_tools = tools.get("mlops_tools", [])
+    env.security_tools = tools.get("security_tools", [])
+    return analysis
+
+
+def test_devops_and_mlops_sections_render(tmp_path: Path) -> None:
+    tools = {
+        "infrastructure_as_code": ["terraform"],
+        "orchestration_tools": ["kubernetes", "helm"],
+        "observability": ["prometheus", "grafana", "opentelemetry"],
+        "security_tools": ["tfsec", "trivy"],
+        "data_pipeline": ["airflow", "dvc"],
+        "mlops_tools": ["mlflow"],
+    }
+    analysis = _make_analysis(tmp_path, tools=tools)
+
+    mgr = ModernTemplateManager()
+    ctx = mgr._create_environment_context(analysis, agent_definitions=[])
+    sections = mgr._render_domain_sections(ctx)
+
+    # DevOps bits
+    assert "Infrastructure as Code" in sections
+    assert "Kubernetes Deployments" in sections
+    assert "Helm Chart" in sections
+    assert "Prometheus" in sections
+    assert "Grafana" in sections
+    assert "OpenTelemetry" in sections
+    assert "tfsec" in sections
+    assert "Trivy" in sections
+
+    # MLOps bits
+    assert "MLflow" in sections
+    assert "Airflow" in sections
+    assert "DVC" in sections
+
+
+def test_no_domain_tools_renders_no_sections(tmp_path: Path) -> None:
+    analysis = _make_analysis(tmp_path, tools={})
+    mgr = ModernTemplateManager()
+    ctx = mgr._create_environment_context(analysis, agent_definitions=[])
+    sections = mgr._render_domain_sections(ctx)
+    assert sections == ""
+
+
+def test_mlops_only_sections(tmp_path: Path) -> None:
+    tools = {
+        "mlops_tools": ["mlflow"],
+        "data_pipeline": ["airflow"],
+    }
+    analysis = _make_analysis(tmp_path, tools=tools)
+    mgr = ModernTemplateManager()
+    ctx = mgr._create_environment_context(analysis, agent_definitions=[])
+    sections = mgr._render_domain_sections(ctx)
+
+    assert "MLflow" in sections
+    assert "Airflow" in sections
+    # Should not include unrelated DevOps content
+    assert "Kubernetes Deployments" not in sections
+    assert "Infrastructure as Code" not in sections


### PR DESCRIPTION
This PR introduces domain-specific documentation templates and integrates them into the generator.

Key changes
- Add DevOps templates: INFRA.md, DEPLOYMENT.md, OBSERVABILITY.md, SECURITY.md
- Add MLOps templates: MLOPS.md, DATA_PIPELINE.md, ML_GOVERNANCE.md
- Extend template search paths to include domain directories
- Inject dev_environment tools into render context and append domain sections to CLAUDE.md only when relevant tools are detected
- Improve renderer to handle dotted variables in conditionals/loops/variables
- Add focused unit tests for domain templates (3 tests passing)
- Update README and CONTRIBUTING with domain template guidance

Linting
- All markdownlint checks pass (no rule disables).

Verification
- Focused tests: ...                                                                      [100%]
3 passed in 0.05s → 3 passed

Notes
- No changes to CLI flags or breaking behavior; domain sections simply appear when matching tools are detected.
