### PR TITLE
Fix: Avoid Reimporting Modules (Resolves #14)

### DIFF
--- a/src/claude_builder/cli/config_commands.py
+++ b/src/claude_builder/cli/config_commands.py
@@ -626,8 +626,6 @@ def reset(project_path: str, *, force: bool) -> None:
         config_manager = ConfigManager()
 
         if not force:
-            from rich.prompt import Confirm
-
             if not Confirm.ask("Reset configuration to defaults?"):
                 console.print("[yellow]Reset cancelled[/yellow]")
                 return

--- a/src/claude_builder/cli/health_commands.py
+++ b/src/claude_builder/cli/health_commands.py
@@ -438,7 +438,6 @@ def _display_report_summary(health: SystemHealth, output_path: Path) -> None:
 def _get_system_info() -> dict[str, Any]:
     """Get detailed system information."""
     import platform
-    import sys
 
     return {
         "platform": platform.platform(),

--- a/src/claude_builder/cli/main.py
+++ b/src/claude_builder/cli/main.py
@@ -214,8 +214,6 @@ def _execute_main(project_path: str, **kwargs: Any) -> None:
             # Generate complete environment (CLAUDE.md + individual subagents + AGENTS.md)
             task2 = progress.add_task("Generating complete environment...", total=None)
 
-            from claude_builder.core.template_manager import TemplateManager
-
             template_manager = TemplateManager()
             environment = template_manager.generate_complete_environment(analysis)
 
@@ -230,8 +228,6 @@ def _execute_main(project_path: str, **kwargs: Any) -> None:
         elif kwargs["agents_only"]:
             # Legacy: agents-only mode
             task2 = progress.add_task("Configuring agents...", total=None)
-
-            from claude_builder.core.template_manager import TemplateManager
 
             template_manager = TemplateManager()
             environment = template_manager.generate_complete_environment(analysis)

--- a/src/claude_builder/core/agents.py
+++ b/src/claude_builder/core/agents.py
@@ -1720,7 +1720,6 @@ class AgentManager:
         """Integrate agent work with GitIntegrationManager."""
         if not getattr(agent, "modifies_git", False):
             return
-        from pathlib import Path
 
         from claude_builder.utils.git import GitIntegrationManager
 

--- a/src/claude_builder/core/analyzer.py
+++ b/src/claude_builder/core/analyzer.py
@@ -670,8 +670,6 @@ class LanguageDetector:
 
     def _analyze_filesystem_for_language_detection(self, project_path: Path) -> Any:
         """Minimal filesystem analysis for language detection."""
-        from claude_builder.core.models import FileSystemInfo
-
         info = FileSystemInfo()
         for item in project_path.rglob("*"):
             if item.is_file():
@@ -880,8 +878,6 @@ class FrameworkDetector:
     def detect_framework(self, project_path: Path, language: str) -> FrameworkInfo:
         """Test-compatible method for detecting frameworks."""
         # Create minimal filesystem analysis and language info
-        from claude_builder.core.models import LanguageInfo
-
         filesystem_info = self._analyze_filesystem_for_framework_detection(project_path)
         language_info = LanguageInfo(primary=language, confidence=100.0)
 
@@ -919,8 +915,6 @@ class FrameworkDetector:
 
     def _analyze_filesystem_for_framework_detection(self, project_path: Path) -> Any:
         """Minimal filesystem analysis for framework detection."""
-        from claude_builder.core.models import FileSystemInfo
-
         info = FileSystemInfo()
         info.root_files = [f.name for f in project_path.iterdir() if f.is_file()]
 
@@ -1130,8 +1124,6 @@ class FrameworkDetector:
 
     def detect_frameworks(self, project_path: Path) -> List[Any]:
         """Detect frameworks in project - test compatibility method."""
-        from claude_builder.core.models import FileSystemInfo, LanguageInfo
-
         # Create mock objects for compatibility
         filesystem_info = FileSystemInfo()
         language_info = LanguageInfo()

--- a/src/claude_builder/core/generator.py
+++ b/src/claude_builder/core/generator.py
@@ -1153,9 +1153,7 @@ ${uses_database == 'Yes' and '''
             try:
                 analysis = getattr(self, "_default_analysis", None)
                 if analysis is not None and hasattr(template, "name"):
-                    from pathlib import Path as _P
-
-                    base = _P(analysis.project_path).parent
+                    base = Path(analysis.project_path).parent
                     alt = base / "templates" / str(getattr(template, "name"))
                     if alt.exists():
                         base_vars: Dict[str, Any] = {}

--- a/src/claude_builder/core/template_manager.py
+++ b/src/claude_builder/core/template_manager.py
@@ -195,12 +195,10 @@ class ModernTemplateManager:
         """
         if self.community_manager is None:
             return []
-        from typing import Any
-        from typing import List as TList
         from typing import cast
 
-        raw: TList[Any] = cast(
-            TList[Any],
+        raw: List[Any] = cast(
+            List[Any],
             self.community_manager.list_available_templates(
                 include_installed=include_installed, include_community=include_community
             ),

--- a/src/claude_builder/core/template_manager.py
+++ b/src/claude_builder/core/template_manager.py
@@ -13,7 +13,7 @@ PHASE 3.1 REFACTORING: Core Module Separation
 import logging
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from claude_builder.core.models import (
     AgentDefinition,
@@ -195,8 +195,6 @@ class ModernTemplateManager:
         """
         if self.community_manager is None:
             return []
-        from typing import cast
-
         raw: List[Any] = cast(
             List[Any],
             self.community_manager.list_available_templates(
@@ -241,12 +239,8 @@ class ModernTemplateManager:
         """Search for templates matching query and project analysis."""
         if self.community_manager is None:
             return []
-        from typing import Any
-        from typing import List as TList
-        from typing import cast
-
-        raw: TList[Any] = cast(
-            TList[Any], self.community_manager.search_templates(query, project_analysis)
+        raw: List[Any] = cast(
+            List[Any], self.community_manager.search_templates(query, project_analysis)
         )
         results: List[CommunityTemplate] = []
         for item in raw:
@@ -352,7 +346,6 @@ class ModernTemplateManager:
         never raises network exceptions directly.
         """
         import json
-        import logging
 
         from urllib.error import HTTPError, URLError
         from urllib.request import Request, urlopen
@@ -398,8 +391,6 @@ class ModernTemplateManager:
 
     def _download_file(self, url: str, destination: Path) -> None:
         """Download a file with strict security checks (legacy-compatible)."""
-        import logging
-
         from urllib.error import HTTPError, URLError
         from urllib.request import Request, urlopen
 
@@ -997,11 +988,7 @@ See AGENTS.md for detailed usage instructions and coordination patterns.
 
             # Fallback to default package template paths
             try:
-                from claude_builder.core.template_manager_legacy import (
-                    CoreTemplateManager as DefaultCore,
-                )
-
-                default_core = DefaultCore()  # uses built-in search paths
+                default_core = CoreTemplateManager()  # uses built-in search paths
                 content = default_core.load_template(name)
                 return default_core.render_template(content, context)
             except Exception:
@@ -1378,12 +1365,8 @@ class TemplateManager(LegacyTemplateManager):
         if not MODULAR_COMPONENTS_AVAILABLE or self.community_manager is None:
             return []
 
-        from typing import Any
-        from typing import List as TList
-        from typing import cast
-
-        raw: TList[Any] = cast(
-            TList[Any],
+        raw: List[Any] = cast(
+            List[Any],
             self.community_manager.list_available_templates(
                 include_installed=include_installed, include_community=include_community
             ),

--- a/src/claude_builder/core/template_manager_legacy.py
+++ b/src/claude_builder/core/template_manager_legacy.py
@@ -1554,9 +1554,6 @@ class TemplateMarketplace:
             api_key: Optional API key for authenticated requests
         """
         # Validate marketplace URL with security validator
-        from claude_builder.utils.exceptions import SecurityError
-        from claude_builder.utils.security import security_validator
-
         try:
             security_validator.validate_url(marketplace_url)
         except SecurityError:


### PR DESCRIPTION
## Summary
- Resolved all 14 instances of PyLintPython3_W0404 violations identified by Codacy
- Systematic fix across 8 files removing duplicate import statements  
- All pre-commit checks passing (black, ruff, mypy, etc.)

## Changes Made
- **CLI modules**: Removed duplicate imports of Confirm, sys, TemplateManager
- **Core modules**: Eliminated duplicate Path, FileSystemInfo, LanguageInfo imports
- **Template system**: Fixed duplicate logging, typing, and CoreTemplateManager imports
- **Legacy modules**: Resolved SecurityError and security_validator reimports

## Files Modified
- `src/claude_builder/cli/config_commands.py`
- `src/claude_builder/cli/health_commands.py`
- `src/claude_builder/cli/main.py` 
- `src/claude_builder/core/agents.py`
- `src/claude_builder/core/analyzer.py`
- `src/claude_builder/core/generator.py`
- `src/claude_builder/core/template_manager.py`
- `src/claude_builder/core/template_manager_legacy.py`

## Testing
- [x] All modified files maintain functionality
- [x] Pre-commit hooks pass (format, lint, type checking)
- [x] Core test suite runs successfully

## Impact
- Improves code clarity and maintainability
- Reduces redundant import statements
- Resolves Codacy code quality violations
- No functional changes to application behavior

## Details
This PR addresses GitHub issue #14 by systematically removing all duplicate import statements that were causing PyLintPython3_W0404 violations. The fixes span across 8 files with a total of 14 instances resolved:

### CLI Layer (3 fixes)
- **config_commands.py**: Removed duplicate `Confirm` import
- **health_commands.py**: Removed duplicate `sys` import  
- **main.py**: Removed duplicate `TemplateManager` imports (2 instances)

### Core Layer (9 fixes)
- **agents.py**: Removed duplicate `Path` import
- **analyzer.py**: Removed duplicate `FileSystemInfo` and `LanguageInfo` imports (4 instances)
- **generator.py**: Optimized Path import aliasing
- **template_manager.py**: Removed duplicate `logging` and typing imports (2 instances)

### Legacy Layer (2 fixes)
- **template_manager_legacy.py**: Removed duplicate `SecurityError` and `security_validator` imports

All changes maintain existing functionality while improving code quality and removing redundant import statements that were flagged by static analysis tools.

Closes #14