### PR TITLE
Fix CI formatting and dependency submission

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,20 +29,14 @@ repos:
         args: [--profile=black, --line-length=88]
         exclude: ^src/claude_builder/templates/
 
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks:
-      - id: black
-        language_version: python3
-        args: [--line-length=88]
-        exclude: ^src/claude_builder/templates/
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.7.2
     hooks:
       - id: ruff
         args: [--fix, --select=F,E402,E403,E501,E711,E712,E713,E714,E721,E722,E731,E741,E742,E743,E902,E999, --ignore=T201,S314,S603,S607]
         exclude: ^(src/claude_builder/templates/|scripts/)
+      - id: ruff-format
+        exclude: ^src/claude_builder/templates/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.11.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==11.0.1
+more-itertools==11.0.2
     # via
     #   jaraco-classes
     #   jaraco-functools
@@ -78,7 +78,7 @@ pycparser==3.0
     # via cffi
 pydantic==2.13.0
     # via claude-builder (pyproject.toml)
-pydantic-core==2.41.5
+pydantic-core==2.46.0
     # via pydantic
 pygments==2.20.0
     # via rich
@@ -86,7 +86,7 @@ pyyaml==6.0.3
     # via claude-builder (pyproject.toml)
 requests==2.33.1
     # via claude-builder (pyproject.toml)
-rich==14.3.4
+rich==15.0.0
     # via claude-builder (pyproject.toml)
 secretstorage==3.5.0
     # via keyring


### PR DESCRIPTION
## Summary
- fix the failing dependency-submission workflow by regenerating `requirements.txt` to a resolvable state
- align local pre-commit formatting with CI by replacing the `black` hook with `ruff-format`
- prevent the Codex integration test file from being reformatted locally into a shape that fails `ruff format --check` in CI

## Verification
- `uv run ruff format --check tests/integration/test_cli_target_workflows.py`
- `uvx --from pip-tools pip-compile --dry-run -o requirements.out requirements.txt`
- `uv run pytest tests/integration/test_cli_target_workflows.py --no-cov -q`
