### PR TITLE
Restore satisfiable click/semgrep/pydantic-core constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 keywords = ["claude", "codex", "gemini", "ai", "development", "automation", "documentation"]
 requires-python = ">=3.11"
 dependencies = [
-    "click>=8.3.3",
+    "click>=8.1.8",
     "pydantic>=2.13.3",
     "rich>=14.3.4",
     "toml>=0.10.0",
@@ -58,7 +58,7 @@ dev = [
     "pre-commit>=4.6.0",
     "bandit>=1.9.4",
     "safety>=3.7.0",
-    "semgrep>=1.161.0",
+    "semgrep>=1.0.0",
     "isort>=8.0.1",
     "coverage[toml]>=7.13.5",
     "radon>=6.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ pycparser==3.0
     # via cffi
 pydantic==2.13.3
     # via claude-builder (pyproject.toml)
-pydantic-core==2.46.0
+pydantic-core==2.46.3
     # via pydantic
 pygments==2.20.0
     # via rich

--- a/src/claude_builder/core/async_generator.py
+++ b/src/claude_builder/core/async_generator.py
@@ -462,8 +462,8 @@ class AsyncDocumentGenerator:
 
 1. **Analysis Phase**: Use `rapid-prototyper` for initial development
 2. **Implementation Phase**: Use appropriate agents based on:
-   - Languages: {', '.join(([analysis.language] if analysis.language else []) + analysis.language_info.secondary)}
-   - Frameworks: {', '.join(([analysis.framework] if analysis.framework else []) + analysis.framework_info.secondary)}
+   - Languages: {", ".join(([analysis.language] if analysis.language else []) + analysis.language_info.secondary)}
+   - Frameworks: {", ".join(([analysis.framework] if analysis.framework else []) + analysis.framework_info.secondary)}
 3. **Testing Phase**: Use `test-writer-fixer` for comprehensive testing
 4. **Documentation Phase**: Use `documentation-engineer` for final docs
 

--- a/src/claude_builder/core/async_generator.py
+++ b/src/claude_builder/core/async_generator.py
@@ -9,7 +9,7 @@ import asyncio
 from datetime import datetime
 from pathlib import Path
 from string import Template as StringTemplate
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import aiofiles
 
@@ -142,7 +142,7 @@ class AsyncDocumentGenerator:
                     cached_result = await cache.get(cache_key)
                     if cached_result is not None and isinstance(cached_result, dict):
                         await self._write_cached_files(cached_result, output_path)
-                        return cached_result  # type: ignore[no-any-return]
+                        return cast(Dict[str, str], cached_result)
 
                 files = {}
 


### PR DESCRIPTION
## Summary
- `pyproject.toml`: lower `click>=8.3.3` → `click>=8.1.8` and `semgrep>=1.161.0` → `semgrep>=1.0.0`. The pair was mutually unsatisfiable since semgrep through 1.162.0 still pins `click~=8.1.8`.
- `requirements.txt`: bump `pydantic-core==2.46.0` → `2.46.3` so pip-compile (Auto Dependency Submission) can resolve against `pydantic==2.13.3`.
- Floors were Dependabot drift, not real version requirements. Codacy already runs semgrep server-side, so it does not need to be a hard floor in `[dev]`.

## Why CI has been red
Since the Apr 27 Dependabot wave (PRs #128, #129, #132), every push to `main` has produced:
- **CI / Required - test matrix (3.11/3.12/3.13)**: `Install dependencies` step fails with uv `No solution found... claude-builder==0.1.0 and claude-builder[dev]==0.1.0 are incompatible` (click 8.3.3 vs semgrep's click<8.2 ceiling).
- **Automatic Dependency Submission (Python)**: pip-compile fails with `ResolutionImpossible: pydantic-core==2.46.0 vs ==2.46.3`.

Both paths resolve cleanly with the changes in this PR.

## Test plan
- [x] `uv pip compile pyproject.toml --extra dev` — succeeds; resolves to `click==8.1.8`, `semgrep==1.162.0`, `pydantic==2.13.4`, `pydantic-core==2.46.4`.
- [x] `uv tool run --from pip-tools pip-compile pyproject.toml --extra dev` (mirrors Auto Dep Submission resolver) — succeeds with same set.
- [x] `uv pip install -e ".[dev]"` in clean Python 3.11 venv — succeeds; `import click; click.__version__ == '8.1.8'`, `import pydantic; pydantic.VERSION == '2.13.4'`.
- [ ] CI matrix on this PR turns green (3.11 / 3.12 / 3.13).
- [ ] Auto Dependency Submission run on this branch turns green.

## Follow-ups (not in this PR)
- Structural fix: single-source on `uv.lock`, drop `requirements.txt`, switch CI to `uv sync`. Tracked in a follow-up PR.
- Tighten `dependabot.yml` (`versioning-strategy: increase-if-necessary`, group dev-deps) so floor-rewriting stops causing this class of regression.

## Do not auto-merge
Wants a human eyes-on after CI is green; this is the third regression of the same shape and the structural fix should land before another Dependabot wave hits.